### PR TITLE
Fix an error caused by SVG

### DIFF
--- a/src/confluence-emoji.js
+++ b/src/confluence-emoji.js
@@ -5,8 +5,11 @@ var gfmEmojis = (':bowtie: :smile: :simple_smile: :laughing: :blush: :smiley: :r
 export default function confluenceEmoji (turndownService) {
   turndownService.addRule('confluenceEmoji', {
     filter: function (node) {
+      if (node.nodeName !== 'IMG') {
+        return false;
+      }
       var classes = (node.className || '').split(' ')
-      return classes.includes('emoticon') && node.nodeName === 'IMG'
+      return classes.includes('emoticon')
     },
     replacement: function (content, node) {
       var dataEmojiShortname = node.getAttribute('data-emoji-shortname') || ''


### PR DESCRIPTION
Currently, `confluenceEmoji` throws an error when it encounters an `svg` tag whose `className` returns `SVGAnimatedString`.

![Screenshot 2024-12-06 at 1 08 43 PM](https://github.com/user-attachments/assets/059861a1-7b65-4413-bb9a-e18c230e2f1e)

This pull request addresses the issue by checking the node name first.
